### PR TITLE
Fix getOrganization return type

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -67,7 +67,7 @@ class User extends Base
      *
      * @param string $name Organization name
      *
-     * @return UserModel
+     * @return Organization
      */
     public function getOrganization($name)
     {


### PR DESCRIPTION
The Client\User::getOrganization() method returns and Organization, but the function comments wrongly states "@return UserModel"
