### PR TITLE
adjustements to the new feature "mutliple hashes, same binary"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+This project tries to follow [Semantic Versioning](http://semver.org/) since the beginning,
+but small API changes may happen between MINOR versions.
+
+This document mainly describes API changes important to users of this library.
+
+## 0.7.0 - unreleased
+
+* BC break! Change `Rokka\Client\Image::getSourceImage($hash, $binaryHash = false, $organization = '')`
+  to `Rokka\Client\Image::getSourceImage($hash, $organization = '')`.
+* Add `Rokka\Client\Image::deleteSourceImagesWithBinaryHash($binaryHash, $organization = '')`.
+* Add `Rokka\Client\Image::getSourceImagesWithBinaryHash($binaryHash, $organization = '')`.
+* Add options parameter to `Rokka\Client\Image::setDynamicMetadata(DynamicMetadataInterface $dynamicMetadata, $hash, $organization = '', $options = [])`.
+  Only option right now is `['deletePrevious' => true]`, defaults to `false`.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,6 @@ This document mainly describes API changes important to users of this library.
 * Add `Rokka\Client\Image::getSourceImagesWithBinaryHash($binaryHash, $organization = '')`.
 * Add options parameter to `Rokka\Client\Image::setDynamicMetadata(DynamicMetadataInterface $dynamicMetadata, $hash, $organization = '', $options = [])`.
   Only option right now is `['deletePrevious' => true]`, defaults to `false`.
+* Add options parameter to `Rokka\Client\Image::deleteDynamicMetadata(DynamicMetadataInterface $dynamicMetadata, $hash, $organization = '', $options = [])`.
+  Only option right now is `['deletePrevious' => true]`, defaults to `false`.
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -116,7 +116,7 @@ class Image extends Base
      *
      * @return bool True if successful, false if image not found
      */
-    public function deleteSourceImagesByBinaryHash($binaryHash, $organization = '')
+    public function deleteSourceImagesWithBinaryHash($binaryHash, $organization = '')
     {
         try {
             $response = $this->call('DELETE', implode('/', [self::SOURCEIMAGE_RESOURCE, $this->getOrganization($organization)]), ['query' => ['binaryHash' => $binaryHash]]);
@@ -226,7 +226,7 @@ class Image extends Base
      *
      * @return SourceImageCollection
      */
-    public function getSourceImagesByBinaryHash($binaryHash, $organization = '')
+    public function getSourceImagesWithBinaryHash($binaryHash, $organization = '')
     {
         $path = self::SOURCEIMAGE_RESOURCE.'/'.$this->getOrganization($organization);
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -105,7 +105,7 @@ class Image extends Base
     }
 
     /**
-     * Delete source images by binaryhash
+     * Delete source images by binaryhash.
      *
      * Since the same binaryhash can have different images in rokka, this may delete more than one picture.
      *
@@ -206,7 +206,6 @@ class Image extends Base
     {
         $path = self::SOURCEIMAGE_RESOURCE.'/'.$this->getOrganization($organization);
 
-
         $path .= '/'.$hash;
 
         $contents = $this
@@ -218,11 +217,11 @@ class Image extends Base
     }
 
     /**
-     * Loads source images metadata from Rokka by binaryhash
+     * Loads source images metadata from Rokka by binaryhash.
      *
      * Since the same binaryhash can have different images in rokka, this may return more than one picture.
      *
-     * @param string $binaryHash         Hash of the image
+     * @param string $binaryHash   Hash of the image
      * @param string $organization Optional organization name
      *
      * @return SourceImageCollection
@@ -236,6 +235,7 @@ class Image extends Base
             ->call('GET', $path, $options)
             ->getBody()
             ->getContents();
+
         return SourceImageCollection::createFromJsonResponse($contents);
     }
 
@@ -383,7 +383,7 @@ class Image extends Base
      *
      * @return string|false
      */
-    public function setDynamicMetadata(DynamicMetadataInterface $dynamicMetadata, $hash, $organization = '', $options = array())
+    public function setDynamicMetadata(DynamicMetadataInterface $dynamicMetadata, $hash, $organization = '', $options = [])
     {
         $path = implode('/', [
             self::SOURCEIMAGE_RESOURCE,

--- a/src/Image.php
+++ b/src/Image.php
@@ -370,7 +370,6 @@ class Image extends Base
      * did not change it.
      *
      * The only option currently can be
-     *
      * ['deletePrevious' => true]
      *
      * which deletes the previous image from rokka (but not the binary, since that's still used)
@@ -379,7 +378,7 @@ class Image extends Base
      * @param DynamicMetadataInterface $dynamicMetadata The Dynamic Metadata
      * @param string                   $hash            The Image hash
      * @param string                   $organization    Optional organization name
-     * @param options                  $options         Optional options
+     * @param array                    $options         Optional options
      *
      * @return string|false
      */
@@ -413,13 +412,19 @@ class Image extends Base
      * Returns the new Hash for the SourceImage, it could be the same as the input one if the operation
      * did not change it.
      *
+     * The only option currently can be
+     * ['deletePrevious' => true]
+     * which deletes the previous image from rokka (but not the binary, since that's still used)
+     * If not set, the original image is kept in rokka.
+     *
      * @param string $dynamicMetadataName The DynamicMetadata name
      * @param string $hash                The Image hash
      * @param string $organization        Optional organization name
+     * @param array  $options             Optional options
      *
      * @return string|false
      */
-    public function deleteDynamicMetadata($dynamicMetadataName, $hash, $organization = '')
+    public function deleteDynamicMetadata($dynamicMetadataName, $hash, $organization = '', $options = [])
     {
         if (empty($hash)) {
             throw new \LogicException('Missing image Hash.');
@@ -437,7 +442,12 @@ class Image extends Base
             $dynamicMetadataName,
         ]);
 
-        $response = $this->call('DELETE', $path);
+        $callOptions = [];
+        if (isset($options['deletePrevious']) && $options['deletePrevious']) {
+            $callOptions['query'] = ['deletePrevious' => 'true'];
+        }
+
+        $response = $this->call('DELETE', $path, $callOptions);
 
         if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
             return $this->extractHashFromLocationHeader($response->getHeader('Location'));


### PR DESCRIPTION
It's backwards compatible (except that the new methods don't work), so this can be merged independently from the merging/deployment of the actual api