### PR TITLE
add iterators to collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project tries to follow [Semantic Versioning](http://semver.org/) since the
 
 This document mainly describes API changes important to users of this library.
 
+## 1.2.0 - unreleased
+
+* `OperationCollection`, `SourceImageCollection` and `StackCollection` implement now the `Iterator` interface.
+
 ## 1.1.0 - 2017-11-13
 
 * Add support for the new `short_hash` property on SourceImage.

--- a/src/Core/OperationCollection.php
+++ b/src/Core/OperationCollection.php
@@ -5,7 +5,7 @@ namespace Rokka\Client\Core;
 /**
  * Represents a collection of image transformation operations in a stack.
  */
-class OperationCollection implements \Countable
+class OperationCollection implements \Countable, \Iterator
 {
     /**
      * Array of operations.
@@ -13,6 +13,11 @@ class OperationCollection implements \Countable
      * @var Operation[]
      */
     private $operations = [];
+
+    /**
+     * @var int
+     */
+    private $current = 0;
 
     /**
      * Constructor.
@@ -64,5 +69,30 @@ class OperationCollection implements \Countable
         }
 
         return new self($operations);
+    }
+
+    public function current()
+    {
+        return $this->operations[$this->current];
+    }
+
+    public function next()
+    {
+        ++$this->current;
+    }
+
+    public function key()
+    {
+        return $this->current;
+    }
+
+    public function valid()
+    {
+        return $this->current < count($this->operations);
+    }
+
+    public function rewind()
+    {
+        $this->current = 0;
     }
 }

--- a/src/Core/SourceImageCollection.php
+++ b/src/Core/SourceImageCollection.php
@@ -5,7 +5,7 @@ namespace Rokka\Client\Core;
 /**
  * Represents a collection of source images.
  */
-class SourceImageCollection implements \Countable
+class SourceImageCollection implements \Countable, \Iterator
 {
     /**
      * Array of source images.
@@ -13,6 +13,11 @@ class SourceImageCollection implements \Countable
      * @var SourceImage[]
      */
     private $sourceImages = [];
+
+    /**
+     * @var int
+     */
+    private $current = 0;
 
     /**
      * The total amount of items from the collection, with pagination.
@@ -121,5 +126,30 @@ class SourceImageCollection implements \Countable
         $cursor = isset($data['cursor']) ? $data['cursor'] : null;
 
         return new self($sourceImages, $total, $links, $cursor);
+    }
+
+    public function current()
+    {
+        return $this->sourceImages[$this->current];
+    }
+
+    public function next()
+    {
+        ++$this->current;
+    }
+
+    public function key()
+    {
+        return $this->current;
+    }
+
+    public function valid()
+    {
+        return $this->current < count($this->sourceImages);
+    }
+
+    public function rewind()
+    {
+        $this->current = 0;
     }
 }

--- a/src/Core/StackCollection.php
+++ b/src/Core/StackCollection.php
@@ -5,12 +5,17 @@ namespace Rokka\Client\Core;
 /**
  * Holds a list of stacks.
  */
-class StackCollection implements \Countable
+class StackCollection implements \Countable, \Iterator
 {
     /**
      * @var Stack[]
      */
     private $stacks = [];
+
+    /**
+     * @var int
+     */
+    private $current = 0;
 
     /**
      * Constructor.
@@ -67,5 +72,30 @@ class StackCollection implements \Countable
         }, $data['items']);
 
         return new self($stacks);
+    }
+
+    public function current()
+    {
+        return $this->stacks[$this->current];
+    }
+
+    public function next()
+    {
+        ++$this->current;
+    }
+
+    public function key()
+    {
+        return $this->current;
+    }
+
+    public function valid()
+    {
+        return $this->current < count($this->stacks);
+    }
+
+    public function rewind()
+    {
+        $this->current = 0;
     }
 }


### PR DESCRIPTION
They were missing, but are in the docs. If we have collections anyway, we should be able to iterate over it.