### PR TITLE
Restore and copy sourceimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project tries to follow [Semantic Versioning](http://semver.org/) since the
 
 This document mainly describes API changes important to users of this library.
 
+## 1.3.0 - unreleased
+
+* Added `\Rokka\Client\Image::restoreSourceImage($hash, $organization)` for restoring deleted images.
+
 ## 1.2.0 - 2018-02-19
 
 * Remove 3rd parameter $apiSecret from `\Rokka\Client\Factory::getImageClient()`. 3rd parameter is now the optional $baseUrl. Backwards compatibility is kept, but you're advised to adjust your clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document mainly describes API changes important to users of this library.
 ## 1.3.0 - unreleased
 
 * Added `\Rokka\Client\Image::restoreSourceImage($hash, $organization)` for restoring deleted images.
+* Added `\Rokka\Client\Image::copySourceImage($hash, $destination, $overwrite, $organization)` for copying an image to another organization.
 
 ## 1.2.0 - 2018-02-19
 

--- a/src/Core/StackUri.php
+++ b/src/Core/StackUri.php
@@ -18,9 +18,9 @@ use Rokka\Client\UriHelper;
  * echo $stackUri->getStackUriString();
  * ```
  *
- * @see Stack::getDynamicUriString()
- * @see UriHelper::addOptionsToUri()
- * @see UriHelper::addOptionsToUriString()
+ * @see \Rokka\Client\Core\Stack::getDynamicUriString()
+ * @see \Rokka\Client\UriHelper::addOptionsToUri()
+ * @see \Rokka\Client\UriHelper::addOptionsToUriString()
  * @since 1.2.0
  */
 class StackUri extends StackAbstract

--- a/src/Image.php
+++ b/src/Image.php
@@ -135,14 +135,12 @@ class Image extends Base
     /**
      * Restore a source image.
      *
-     * @param string $hash         Hash of the image
+     * @param string $hash Hash of the image
      * @param string $organization Optional organization name
      *
      * @throws GuzzleException If the request fails for a different reason than image not found
      *
      * @return bool True if successful, false if image not found
-     *
-     * @throws \Exception
      */
     public function restoreSourceImage($hash, $organization = '')
     {
@@ -152,12 +150,46 @@ class Image extends Base
             if (404 == $e->getCode()) {
                 return false;
             }
-
             throw $e;
         }
 
         return '200' == $response->getStatusCode();
     }
+
+
+    /**
+     * Copy a source image to another org
+     *
+     * @param string $hash Hash of the image
+     * @param string $destinationOrg The destination organization
+     * @param bool $overwrite If an existing image should be overwritten
+     * @param string $organization Optional organization name
+     *
+     * @throws GuzzleException If the request fails for a different reason than image not found
+     *
+     * @return bool True if successful, false if source image not found
+     */
+    public function copySourceImage($hash, $destinationOrg, $overwrite = true, $organization = '')
+    {
+        try {
+            $headers = ['Destination' => $destinationOrg];
+            if ($overwrite === false) {
+                $headers['Overwrite'] = 'F';
+            }
+            $response = $this->call('COPY',
+                implode('/', [self::SOURCEIMAGE_RESOURCE, $this->getOrganization($organization), $hash]),
+                ['headers' => $headers]
+            );
+        } catch (GuzzleException $e) {
+            if (404 == $e->getCode()) {
+                return false;
+            }
+            throw $e;
+        }
+        $statusCode = $response->getStatusCode();
+        return  $statusCode >= 200 && $statusCode < 300;
+    }
+
     /**
      * Delete source images by binaryhash.
      *

--- a/src/Image.php
+++ b/src/Image.php
@@ -135,7 +135,7 @@ class Image extends Base
     /**
      * Restore a source image.
      *
-     * @param string $hash Hash of the image
+     * @param string $hash         Hash of the image
      * @param string $organization Optional organization name
      *
      * @throws GuzzleException If the request fails for a different reason than image not found
@@ -150,20 +150,20 @@ class Image extends Base
             if (404 == $e->getCode()) {
                 return false;
             }
+
             throw $e;
         }
 
         return '200' == $response->getStatusCode();
     }
 
-
     /**
-     * Copy a source image to another org
+     * Copy a source image to another org.
      *
-     * @param string $hash Hash of the image
+     * @param string $hash           Hash of the image
      * @param string $destinationOrg The destination organization
-     * @param bool $overwrite If an existing image should be overwritten
-     * @param string $organization Optional organization name
+     * @param bool   $overwrite      If an existing image should be overwritten
+     * @param string $organization   Optional organization name
      *
      * @throws GuzzleException If the request fails for a different reason than image not found
      *
@@ -173,7 +173,7 @@ class Image extends Base
     {
         try {
             $headers = ['Destination' => $destinationOrg];
-            if ($overwrite === false) {
+            if (false === $overwrite) {
                 $headers['Overwrite'] = 'F';
             }
             $response = $this->call('COPY',
@@ -184,9 +184,11 @@ class Image extends Base
             if (404 == $e->getCode()) {
                 return false;
             }
+
             throw $e;
         }
         $statusCode = $response->getStatusCode();
+
         return  $statusCode >= 200 && $statusCode < 300;
     }
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -133,6 +133,32 @@ class Image extends Base
     }
 
     /**
+     * Restore a source image.
+     *
+     * @param string $hash         Hash of the image
+     * @param string $organization Optional organization name
+     *
+     * @throws GuzzleException If the request fails for a different reason than image not found
+     *
+     * @return bool True if successful, false if image not found
+     *
+     * @throws \Exception
+     */
+    public function restoreSourceImage($hash, $organization = '')
+    {
+        try {
+            $response = $this->call('POST', implode('/', [self::SOURCEIMAGE_RESOURCE, $this->getOrganization($organization), $hash, 'restore']));
+        } catch (GuzzleException $e) {
+            if (404 == $e->getCode()) {
+                return false;
+            }
+
+            throw $e;
+        }
+
+        return '200' == $response->getStatusCode();
+    }
+    /**
      * Delete source images by binaryhash.
      *
      * Since the same binaryhash can have different images in rokka, this may delete more than one picture.

--- a/src/Image.php
+++ b/src/Image.php
@@ -160,16 +160,18 @@ class Image extends Base
     /**
      * Copy a source image to another org.
      *
+     * Needs read permissions on the source organization and write permissions on the write organization.
+     *
      * @param string $hash           Hash of the image
      * @param string $destinationOrg The destination organization
      * @param bool   $overwrite      If an existing image should be overwritten
-     * @param string $organization   Optional organization name
+     * @param string $sourceOrg      Optional source organization name
      *
      * @throws GuzzleException If the request fails for a different reason than image not found
      *
      * @return bool True if successful, false if source image not found
      */
-    public function copySourceImage($hash, $destinationOrg, $overwrite = true, $organization = '')
+    public function copySourceImage($hash, $destinationOrg, $overwrite = true, $sourceOrg = '')
     {
         try {
             $headers = ['Destination' => $destinationOrg];
@@ -177,7 +179,7 @@ class Image extends Base
                 $headers['Overwrite'] = 'F';
             }
             $response = $this->call('COPY',
-                implode('/', [self::SOURCEIMAGE_RESOURCE, $this->getOrganization($organization), $hash]),
+                implode('/', [self::SOURCEIMAGE_RESOURCE, $this->getOrganization($sourceOrg), $hash]),
                 ['headers' => $headers]
             );
         } catch (GuzzleException $e) {


### PR DESCRIPTION
* Added `\Rokka\Client\Image::restoreSourceImage($hash, $organization)` for restoring deleted images.
* Added `\Rokka\Client\Image::copySourceImage($hash, $destination, $overwrite, $organization)` for copying an image to another organization. (needs backend merge first)
