### PR TITLE
Dynamic version object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ This document mainly describes API changes important to users of this library.
 
 ## 1.8.0 - 2018-10-xx
 
-* Added an object for the new dynamic metadata "version".
+* Added an object for the new dynamic metadata "version". 
+  See https://rokka.io//documentation/references/dynamic-metadata.html#version for details 
 * $option in `\Rokka\Client\Image::uploadSourceImage` and `\Rokka\Client\Image::setDynamicMetadata` now takes either
   a single DynamicMetaData Object or an array with the needed fields. Or an array thereof for multiple new sets.
-
+  
 ## 1.7.0 - 2018-10-25
 
 * Added new membership methods to `\Rokka\Client\User`. It's not totally backwards compatible, but the methods changed were not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project tries to follow [Semantic Versioning](http://semver.org/) since the
 
 This document mainly describes API changes important to users of this library.
 
+## 1.8.0 - 2018-10-xx
+
+* Added an object for the new dynamic metadata "version".
+* $option in `\Rokka\Client\Image::uploadSourceImage` and `\Rokka\Client\Image::setDynamicMetadata` now takes either
+  a single DynamicMetaData Object or an array with the needed fields. Or an array thereof for multiple new sets.
+
 ## 1.7.0 - 2018-10-25
 
 * Added new membership methods to `\Rokka\Client\User`. It's not totally backwards compatible, but the methods changed were not

--- a/src/Core/DynamicMetadata/Version.php
+++ b/src/Core/DynamicMetadata/Version.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rokka\Client\Core\DynamicMetadata;
+
+class Version implements DynamicMetadataInterface
+{
+    /**
+     * @var string
+     */
+    public $text;
+
+    public function __construct(string $text)
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return string The name of the metadata
+     */
+    public static function getName()
+    {
+        return 'version';
+    }
+
+    /**
+     * Create a CropArea from the decoded JSON data.
+     *
+     * @param array $data Decoded JSON data
+     *
+     * @return Version
+     */
+    public static function createFromDecodedJsonResponse($data)
+    {
+        $object = new self($data['text']);
+
+        return $object;
+    }
+
+    public function getForJson()
+    {
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText(string $text)
+    {
+        $this->text = $text;
+    }
+}

--- a/src/Image.php
+++ b/src/Image.php
@@ -5,6 +5,7 @@ namespace Rokka\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use Rokka\Client\Core\DynamicMetadata\DynamicMetadataInterface;
 use Rokka\Client\Core\OperationCollection;
@@ -571,6 +572,7 @@ class Image extends Base
         }
 
         $count = 0;
+        $response = null;
         foreach ($dynamicMetadata as $value => $data) {
             $callOptions = [];
             if ($data instanceof DynamicMetadataInterface) {
@@ -601,11 +603,14 @@ class Image extends Base
             }
             $hash = $this->extractHashFromLocationHeader($response->getHeader('Location'));
         }
-        if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
-            return $hash;
+        if ($response instanceof ResponseInterface) {
+            if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
+                return $hash;
+            }
+            // Throw an exception to be handled by the caller.
+            throw new \LogicException($response->getBody()->getContents(), $response->getStatusCode());
         }
-        // Throw an exception to be handled by the caller.
-        throw new \LogicException($response->getBody()->getContents(), $response->getStatusCode());
+        throw new \LogicException('Something went wrong with the call/response to the rokka API', 0);
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -553,37 +553,57 @@ class Image extends Base
      * which deletes the previous image from rokka (but not the binary, since that's still used)
      * If not set, the original image is kept in rokka.
      *
-     * @param DynamicMetadataInterface $dynamicMetadata The Dynamic Metadata
-     * @param string                   $hash            The Image hash
-     * @param string                   $organization    Optional organization name
-     * @param array                    $options         Optional options
+     * @param DynamicMetadataInterface|array $dynamicMetadata A Dynamic Metadata object, an array with all the needed info.
+     *                                                        Or an array with more than one of those.
+     * @param string                         $hash            The Image hash
+     * @param string                         $organization    Optional organization name
+     * @param array                          $options         Optional options
      *
      * @throws GuzzleException
      * @throws \RuntimeException
      *
      * @return string|false
      */
-    public function setDynamicMetadata(DynamicMetadataInterface $dynamicMetadata, $hash, $organization = '', $options = [])
+    public function setDynamicMetadata($dynamicMetadata, $hash, $organization = '', $options = [])
     {
-        $path = implode('/', [
-            self::SOURCEIMAGE_RESOURCE,
-            $this->getOrganizationName($organization),
-            $hash,
-            self::DYNAMIC_META_RESOURCE,
-            $dynamicMetadata::getName(),
-        ]);
-        $callOptions = [];
-        $callOptions['json'] = $dynamicMetadata->getForJson();
-        if (isset($options['deletePrevious']) && $options['deletePrevious']) {
-            $callOptions['query'] = ['deletePrevious' => 'true'];
+        if (!\is_array($dynamicMetadata)) {
+            $dynamicMetadata = [$dynamicMetadata];
         }
 
-        $response = $this->call('PUT', $path, $callOptions);
+        $count = 0;
+        foreach ($dynamicMetadata as $value => $data) {
+            $callOptions = [];
+            if ($data instanceof DynamicMetadataInterface) {
+                $name = $data::getName();
+                $callOptions['json'] = $data->getForJson();
+            } else {
+                $name = $value;
+                $callOptions['json'] = $data;
+            }
 
+            $path = implode('/', [
+                self::SOURCEIMAGE_RESOURCE,
+                $this->getOrganizationName($organization),
+                $hash,
+                self::DYNAMIC_META_RESOURCE,
+                $name,
+            ]);
+
+            // delete the previous, if we're not on the first one anymore, or if we want to delete it.
+            if ($count > 0 || (0 === $count && isset($options['deletePrevious']) && $options['deletePrevious'])) {
+                $callOptions['query'] = ['deletePrevious' => 'true'];
+            }
+
+            ++$count;
+            $response = $this->call('PUT', $path, $callOptions);
+            if (!($response->getStatusCode() >= 200 && $response->getStatusCode() < 300)) {
+                throw new \LogicException($response->getBody()->getContents(), $response->getStatusCode());
+            }
+            $hash = $this->extractHashFromLocationHeader($response->getHeader('Location'));
+        }
         if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
-            return $this->extractHashFromLocationHeader($response->getHeader('Location'));
+            return $hash;
         }
-
         // Throw an exception to be handled by the caller.
         throw new \LogicException($response->getBody()->getContents(), $response->getStatusCode());
     }
@@ -866,6 +886,10 @@ class Image extends Base
 
         if (isset($options['meta_dynamic'])) {
             foreach ($options['meta_dynamic'] as $key => $value) {
+                if ($value instanceof  DynamicMetadataInterface) {
+                    $key = $value::getName();
+                    $value = $value->getForJson();
+                }
                 $requestOptions[] = [
                     'name' => 'meta_dynamic[0]['.$key.']',
                     'contents' => json_encode($value),

--- a/src/Image.php
+++ b/src/Image.php
@@ -610,6 +610,7 @@ class Image extends Base
             // Throw an exception to be handled by the caller.
             throw new \LogicException($response->getBody()->getContents(), $response->getStatusCode());
         }
+
         throw new \LogicException('Something went wrong with the call/response to the rokka API', 0);
     }
 


### PR DESCRIPTION
* Added an object for the new dynamic metadata "version".
* $option in `\Rokka\Client\Image::uploadSourceImage` and `\Rokka\Client\Image::setDynamicMetadata` now takes either
  a single DynamicMetaData Object or an array with the needed fields. Or an array thereof for multiple new sets.

- [ ] API Merge and deploy