### PR TITLE
Fix: Allows searches for user metadata of type integer

### DIFF
--- a/src/SearchHelper.php
+++ b/src/SearchHelper.php
@@ -17,7 +17,7 @@ class SearchHelper
     public static function validateFieldName($fieldName)
     {
         // Field names must be shorter than 54 chars, and match the given format.
-        return 54 > \strlen($fieldName) && 1 === preg_match('/^(user:((str|array|date|latlon|double):)?)?[a-z0-9_]{1,54}$/', $fieldName);
+        return 54 > \strlen($fieldName) && 1 === preg_match('/^(user:((str|array|date|latlon|int|double):)?)?[a-z0-9_]{1,54}$/', $fieldName);
     }
 
     /**


### PR DESCRIPTION
This allows searching for source images by user metadata that are of type int as described on https://rokka.io/documentation/references/user-metadata.html