### PR TITLE
Widen firebase/php-jwt constraint to support v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "guzzlehttp/psr7": "^1.9.1|^2.4.5",
         "ext-json": "*",
         "rokka/utils": "^1.0",
-        "firebase/php-jwt": "^6.0"
+        "firebase/php-jwt": "^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.25",


### PR DESCRIPTION
## Summary

- Widens `firebase/php-jwt` constraint from `^6.0` to `^6.0 || ^7.0`

## Motivation

Projects that depend on both `rokka/client` and packages like `google/apiclient` or `google/auth` are unable to install `rokka/client` >= 1.17, because those Google packages now resolve `firebase/php-jwt` to v7.x, which conflicts with the current `^6.0` constraint.

Composer's solver is forced to downgrade `rokka/client` to 1.16.0 (the last version without the `firebase/php-jwt` dependency).

## Why this is safe

The breaking changes in `firebase/php-jwt` v7.0 are limited to stricter cryptographic key size validation. The core `JWT::encode()` / `JWT::decode()` API remains unchanged.

Fixes #85